### PR TITLE
Remove pf2e system requirement

### DIFF
--- a/module.json
+++ b/module.json
@@ -24,13 +24,6 @@
         }
     ],
     "relationships": {
-        "systems": [
-            {
-                "id": "pf2e",
-                "type": "system",
-                "manifest": "https://github.com/foundryvtt/pf2e/releases/latest/download/system.json"
-            }
-        ],
         "requires": [
             {
                 "id": "lib-wrapper",

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -90,6 +90,15 @@ function updateExploration() {
     );
 }
 
+function hasGmVision() {
+    switch (game.system.id) {
+        case 'pf2e':
+            return game.settings.get("pf2e", "gmVision");
+        default:
+            return true;
+    }
+}
+
 Hooks.once("ready", () => {
     libWrapper.register<TokenPF2e, TokenPF2e["findMovementPath"]>(
         "wayfinder",


### PR DESCRIPTION
The pf2e system requirement is not needed. This module works perfectly in dnd5e system if we just remove the gmVision settings check.

I didn't touch the rest of the code, including the TypeScript types imported from foundry-pf2e, as these have no impact on the final code at runtime.

This module could be completely system agnostic, and everyone would benefit from it.